### PR TITLE
Add kwarg to prevent updated attribute clearing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    activerecord_batch_update (1.0.1)
+    activerecord_batch_update (1.0.2)
       activerecord (>= 7.0, < 8.1)
       activesupport (>= 7.0, < 8.1)
 

--- a/activerecord_batch_update.gemspec
+++ b/activerecord_batch_update.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'activerecord_batch_update'
-  s.version     = '1.0.1'
+  s.version     = '1.0.2'
   s.summary     = 'Update multiple records with different values in a small number of queries'
   s.description = ''
   s.authors     = ['Quentin de Metz']

--- a/lib/activerecord_batch_update.rb
+++ b/lib/activerecord_batch_update.rb
@@ -14,7 +14,7 @@ module ActiveRecordBatchUpdate
   # which will re-insert the objects if they were deleted in another thread
 
   module ClassMethods
-    def batch_update(entries, columns:, batch_size: 100, validate: true)
+    def batch_update(entries, columns:, batch_size: 100, validate: true, clear_attribute_changes: true)
       columns = column_names if columns == :all
       columns = (Array.wrap(columns).map(&:to_s) + %w[updated_at]).uniq
 
@@ -35,7 +35,7 @@ module ActiveRecordBatchUpdate
       end
 
       connection.clear_query_cache if connection.query_cache_enabled
-      entries.each { _1.clear_attribute_changes(columns) }
+      entries.each { _1.clear_attribute_changes(columns) } if clear_attribute_changes
 
       updated_count
     end

--- a/spec/activerecord_batch_update_spec.rb
+++ b/spec/activerecord_batch_update_spec.rb
@@ -187,6 +187,15 @@ describe ActiveRecordBatchUpdate do # rubocop:disable RSpec/SpecFilePathFormat
 
           expect(cat1.changes_to_save).to be_empty
         end
+
+        context 'with the clear_attribute_changes option as false' do
+          it 'does not clear any changes after the update' do
+            cat1.name = 'Nala'
+            Cat.batch_update([cat1], columns: :all, clear_attribute_changes: false)
+
+            expect(cat1.changes_to_save.keys).to contain_exactly('name', 'updated_at')
+          end
+        end
       end
 
       context 'when saving only some of the dirty attributes' do


### PR DESCRIPTION
Following changes made in [this PR](https://github.com/pennylane-hq/activerecord_batch_update/pull/12), we are adding a keyword arg option to allow the original behaviour to be retained if required.

This will ease transitions towards the gem fix, and may be removed in the next major release.